### PR TITLE
Initialize Next.js skeleton

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "store",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "private": true,
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/api/orders.js
+++ b/pages/api/orders.js
@@ -1,0 +1,11 @@
+let orders = [];
+
+export default function handler(req, res) {
+  if (req.method === 'POST') {
+    const order = req.body;
+    orders.push(order);
+    res.status(201).json(order);
+  } else {
+    res.status(200).json(orders);
+  }
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export default function Dashboard() {
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/orders')
+      .then((res) => res.json())
+      .then((data) => setOrders(data));
+  }, []);
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      {orders.length === 0 ? (
+        <p>No orders found.</p>
+      ) : (
+        <ul>
+          {orders.map((order, index) => (
+            <li key={index}>
+              {order.item} - {order.quantity}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Storefront</h1>
+      <p>Welcome to the store.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- init Next.js scaffolding
- add storefront and dashboard pages
- implement minimal orders API route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a039d5888321adbfaa07d26cb0bd